### PR TITLE
Add two notes to Matrix integration

### DIFF
--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -82,6 +82,12 @@ commands:
       default: empty
 {% endconfiguration %}
 
+<div class="note">
+
+In order to prevent infinite loops when reacting to commands, you have to use a separate account for the Matrix integration.
+
+</div>
+
 ### Event Data
 
 If a command is triggered, a `matrix_command` event is fired. The event contains the name of the command in the `name` field.
@@ -190,3 +196,17 @@ action:
       images:
         - /path/to/picture.jpg
 ```
+
+<div class='note'>
+
+Since Home Assistant version 0.48 you have to [whitelist the source folder](/docs/configuration/basic/) of the file you want to include in the notification.
+
+```yaml
+configuration.yaml
+...
+homeassistant:
+  allowlist_external_dirs:
+    - /tmp
+```
+
+</div>

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -199,7 +199,7 @@ action:
 
 <div class='note'>
 
-Since Home Assistant version 0.48 you have to [whitelist the source folder](/docs/configuration/basic/) of the file you want to include in the notification.
+If you need to include a file from an external folder in your notifications, you will have to [whitelist the source folder](/docs/configuration/basic/).
 
 ```yaml
 configuration.yaml

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -199,7 +199,7 @@ action:
 
 <div class='note'>
 
-If you need to include a file from an external folder in your notifications, you will have to [whitelist the source folder](/docs/configuration/basic/).
+If you need to include a file from an external folder in your notifications, you will have to [list the source folder as allowed](/docs/configuration/basic/).
 
 ```yaml
 configuration.yaml


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This pull request adds two notes to the documentation of the Matrix integration.

The second note is copied from the documentation of the telegram integration (source/_integrations/telegram.markdown).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
